### PR TITLE
Convert to @pkgjs/create

### DIFF
--- a/bin/create-git
+++ b/bin/create-git
@@ -1,33 +1,3 @@
 #!/usr/bin/env node
 'use strict'
-// vim: set ft=javascript:ts=2:sw=2
-const program = require('commander')
-const pkg = require('../package.json')
-const createGit = require('../')
-const arrayFromList = require('../lib/array-from-list')
-
-let directory
-program
-  .version(pkg.version)
-  .arguments('<directory>')
-  .action((dir) => directory = dir)
-  .option('--ignore-existing', 'Ignore existing package.json')
-  .option('--silent', 'Surpress output')
-  .option('--no-prompt', 'Skip prompts and just use input options')
-  .option('-m --initial-commit-message', 'The initial commit message')
-  .option('-o --origin', 'Set the remote origin')
-  .option('-t --templates', 'Ignor templates to load')
-  .parse(process.argv)
-
-if (program.templates) {
-  program.templates = arrayFromList(program.templates)
-}
-
-// Run the process
-createGit({
-  directory: directory,
-  ignoreExisting: program.ignoreExisting,
-  silent: program.silent,
-  remoteOrigin: program.origin,
-  ignoreTemplates: program.templates
-})
+require('../').cli(process.argv.slice(2))

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const create = require('@pkgjs/create')
 const path = require('path')
-const axios = require('axios')
+const got = require('got')
 const shell = require('shelljs')
 const fs = require('fs-extra')
 const parseIgnore = require('./lib/ignore')
@@ -115,10 +115,10 @@ module.exports = create({
   for (var i in opts.ignoreTemplates) {
     try {
       const url = `https://raw.githubusercontent.com/github/gitignore/master/${opts.ignoreTemplates[i]}`
-      const resp = await axios.get(url)
+      const resp = await got(url)
 
       // Join sections
-      ignoreRules.concat(resp.data)
+      ignoreRules.concat(resp.body)
     } catch (e) {
       console.error('Unable to load template', e)
     }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postpublish": "git push origin && git push origin --tags"
   },
   "dependencies": {
+    "@pkgjs/create": "0.0.1",
     "axios": "^0.19.0",
     "commander": "^2.19.0",
     "fs-extra": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@pkgjs/create": "0.0.1",
-    "axios": "^0.19.0",
     "commander": "^2.19.0",
     "fs-extra": "^7.0.0",
+    "got": "^9.6.0",
     "inquirer": "^6.2.0",
     "parse-gitignore": "^1.0.1",
     "shelljs": "^0.8.2"

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ describe('create git', () => {
   it('should initialize a git repo', async () => {
     await createGit({
       directory: TMP_DIR,
-      noPrompt: true,
+      prompt: false,
       silent: true,
       remoteOrigin: 'git@github.com:wesleytodd/create-git.git'
     })
@@ -37,8 +37,9 @@ describe('create git', () => {
 
     await createGit({
       directory: TMP_DIR,
-      noPrompt: true,
-      silent: true
+      prompt: false,
+      silent: true,
+      ignoreTemplates: []
     })
 
     assert(fs.pathExists(path.join(TMP_DIR, '.gitignore')))
@@ -51,7 +52,7 @@ describe('create git', () => {
 
     await createGit({
       directory: TMP_DIR,
-      noPrompt: true,
+      prompt: false,
       silent: true,
       ignoreTemplates: [
         'Node.gitignore'
@@ -68,7 +69,7 @@ describe('create git', () => {
 
     await createGit({
       directory: TMP_DIR,
-      noPrompt: true,
+      prompt: false,
       silent: true,
       initialCommitMessage: 'testing'
     })
@@ -92,7 +93,7 @@ describe('create git', () => {
 
     await createGit({
       directory: TMP_DIR,
-      noPrompt: true,
+      prompt: false,
       silent: true
     })
 


### PR DESCRIPTION
As the title says, moves all the boilerplate into a new shared project.