### PR TITLE
feat: use promptor for remote origin question

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const opta = require('opta')
 const parseList = require('safe-parse-list')
 const fs = require('fs-extra')
 const got = require('got')
-const inquirer = require('inquirer')
 const { Loggerr } = require('loggerr')
 const parseIgnore = require('./lib/ignore')
 
@@ -82,6 +81,18 @@ function initOpts () {
         },
         prompt: {
           message: 'Set remote origin:'
+        }
+      },
+      switchToRemoteOrigin: {
+        description: 'Switch to remote origin if different',
+        type: 'boolean',
+        flag: {
+          key: 'switch-to-remote-origin'
+        },
+        prompt: {
+          group: 'switchtoRemoteOrigin',
+          message: (opts) => `Would you like to switch to point to ${opts.remoteOrigin}?`,
+          type: 'confirm'
         }
       },
       ignoreTemplates: {
@@ -268,12 +279,11 @@ async function main (input, _opts = {}) {
 
         if (url !== opts.remoteOrigin) {
           log.error(`remote origin already exists and points somewhere else: ${url}`)
-          const { shouldSwitch } = await inquirer.prompt([{
-            name: 'shouldSwitch',
-            message: `Would you like to switch to point to ${opts.remoteOrigin}?`,
-            type: 'confirm'
-          }])
-          if (shouldSwitch) {
+          const { switchToRemoteOrigin } = await options.prompt({
+            promptor: _opts.promptor,
+            groups: ['switchToPrimaryBranch']
+          })(opts)
+          if (switchToRemoteOrigin) {
             await git(['remote', 'rm', 'origin'], {
               cwd: opts.cwd,
               log

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "fs-extra": "^11.1.1",
     "got": "^11.8.6",
-    "inquirer": "^8.2.6",
     "loggerr": "^3.3.0",
     "opta": "^1.0.2",
     "parse-gitignore": "^1.0.1",


### PR DESCRIPTION
It was using `inquirer` directly, which made it difficult for wrapping tools to mock and override the prompts.